### PR TITLE
Add declaration

### DIFF
--- a/find-free-port-sync.js
+++ b/find-free-port-sync.js
@@ -93,7 +93,7 @@ FindFreePortSync.prototype = {
                 encoding: 'utf-8'
             });
 
-            usedPorts = res.match(reg);
+            let usedPorts = res.match(reg);
 
             // special address usage for  ip.port
             if (!usedPorts) {


### PR DESCRIPTION
Any bundler that compiles this in strict mode will error out due to the lack of a `let` or `var`.